### PR TITLE
Disable proposal actions during decline flow

### DIFF
--- a/YourDay/Views/Scheduling/ProposalMessageCard.swift
+++ b/YourDay/Views/Scheduling/ProposalMessageCard.swift
@@ -12,6 +12,7 @@ struct ProposalMessageCard: View {
     @ObservedObject var schedulingViewModel: SchedulingAssistantViewModel
     @ObservedObject var backlogViewModel: BacklogViewModel
     let onAccept: ([String]) -> Void
+    let isDisabled: Bool
 
     @State private var selectedStartTime: Date
     @State private var adjustedDuration: Int
@@ -24,11 +25,18 @@ struct ProposalMessageCard: View {
     @State private var pendingOriginalTime = "" // Captured original time for popup
     @State private var pendingModifiedTime = "" // Captured modified time for popup
 
-    init(proposal: Binding<ProposedSession>, schedulingViewModel: SchedulingAssistantViewModel, backlogViewModel: BacklogViewModel, onAccept: @escaping ([String]) -> Void) {
+    init(
+        proposal: Binding<ProposedSession>,
+        schedulingViewModel: SchedulingAssistantViewModel,
+        backlogViewModel: BacklogViewModel,
+        isDisabled: Bool = false,
+        onAccept: @escaping ([String]) -> Void
+    ) {
         self._proposal = proposal
         self.schedulingViewModel = schedulingViewModel
         self.backlogViewModel = backlogViewModel
         self.onAccept = onAccept
+        self.isDisabled = isDisabled
 
         // Initialize state from proposal
         let initialStart = proposal.wrappedValue.effectiveStartTime ?? proposal.wrappedValue.startTime ?? Date()
@@ -296,11 +304,14 @@ struct ProposalMessageCard: View {
                     .cornerRadius(6)
                 }
             }
+            .disabled(isDisabled)
+            .opacity(isDisabled ? 0.5 : 1)
         }
         .padding()
         .background(dynamicSecondaryBackgroundColor)
         .cornerRadius(12)
         .frame(maxWidth: 320)
+        .opacity(isDisabled ? 0.7 : 1)
         .id("proposal")
         .sheet(isPresented: $showingCalendarView) {
             DraggableCalendarView(

--- a/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
+++ b/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
@@ -314,6 +314,7 @@ struct SmartSchedulingTestView: View {
                                         ),
                                         schedulingViewModel: schedulingViewModel,
                                         backlogViewModel: backlogViewModel,
+                                        isDisabled: schedulingViewModel.showingDeclineReasonInput,
                                         onAccept: { taskTitles in
                                             // Mark tasks as processed (scheduled or skipped)
                                             if !taskTitles.isEmpty {
@@ -1186,4 +1187,3 @@ struct StatBadge: View {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Keep the proposal UI consistent when the user is entering a decline reason by disabling proposal actions and visually dimming the card while the decline flow is active.

### Description
- Add an `isDisabled: Bool` parameter (default `false`) to `ProposalMessageCard` and store it in the view initializer.
- Disable action controls with `.disabled(isDisabled)` and dim the inner controls and the card using `.opacity(...)` when `isDisabled` is true.
- Pass `isDisabled: schedulingViewModel.showingDeclineReasonInput` into `ProposalMessageCard` from `SmartSchedulingTestView` so the card reflects the decline-reason state.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d69c1310483259563b15e464b43ac)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that gates proposal interactions during the decline-reason prompt; primary risk is minor UX regressions (e.g., disabling too broadly or unexpected dimming).
> 
> **Overview**
> Prevents users from interacting with the current proposal while they are entering a decline reason.
> 
> `ProposalMessageCard` now accepts an `isDisabled` flag (default `false`) and uses it to disable the action controls and visually dim the card via `.disabled`/`.opacity`. `SmartSchedulingTestView` passes `isDisabled: schedulingViewModel.showingDeclineReasonInput` so the proposal UI is consistently locked during the decline flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ec81298296aef4aa4f3d59ab93d3a3900e57ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->