### PR TITLE
Move modification feedback sheet to parent scheduling view

### DIFF
--- a/YourDay/Views/Scheduling/ProposalMessageCard.swift
+++ b/YourDay/Views/Scheduling/ProposalMessageCard.swift
@@ -12,23 +12,26 @@ struct ProposalMessageCard: View {
     @ObservedObject var schedulingViewModel: SchedulingAssistantViewModel
     @ObservedObject var backlogViewModel: BacklogViewModel
     let onAccept: ([String]) -> Void
+    let onRequestModificationReason: (ModificationContext) -> Void
 
     @State private var selectedStartTime: Date
     @State private var adjustedDuration: Int
     @State private var showingCalendarView = false
     @State private var showingAddTaskSheet = false
     @State private var addedTaskTitles: Set<String> = [] // Track tasks added by user
-    @State private var showingModificationReasonPopup = false
-    @State private var modificationReason = ""
-    @State private var pendingAcceptTasks: [String] = [] // Tasks to mark as accepted after reason submitted
-    @State private var pendingOriginalTime = "" // Captured original time for popup
-    @State private var pendingModifiedTime = "" // Captured modified time for popup
 
-    init(proposal: Binding<ProposedSession>, schedulingViewModel: SchedulingAssistantViewModel, backlogViewModel: BacklogViewModel, onAccept: @escaping ([String]) -> Void) {
+    init(
+        proposal: Binding<ProposedSession>,
+        schedulingViewModel: SchedulingAssistantViewModel,
+        backlogViewModel: BacklogViewModel,
+        onAccept: @escaping ([String]) -> Void,
+        onRequestModificationReason: @escaping (ModificationContext) -> Void
+    ) {
         self._proposal = proposal
         self.schedulingViewModel = schedulingViewModel
         self.backlogViewModel = backlogViewModel
         self.onAccept = onAccept
+        self.onRequestModificationReason = onRequestModificationReason
 
         // Initialize state from proposal
         let initialStart = proposal.wrappedValue.effectiveStartTime ?? proposal.wrappedValue.startTime ?? Date()
@@ -237,15 +240,16 @@ struct ProposalMessageCard: View {
                         schedulingViewModel.acceptProposal(backlogItems: backlogViewModel.backlogItems) { scheduledTasks in
                             if !scheduledTasks.isEmpty {
                                 if wasModified {
-                                    // Store data for modification reason popup
-                                    pendingAcceptTasks = scheduledTasks
-                                    pendingOriginalTime = originalTime
-                                    pendingModifiedTime = modifiedTimeStr
-                                    // Show modification reason popup
-                                    showingModificationReasonPopup = true
+                                    onRequestModificationReason(
+                                        ModificationContext(
+                                            tasks: scheduledTasks,
+                                            originalTime: originalTime,
+                                            modifiedTime: modifiedTimeStr
+                                        )
+                                    )
+                                } else {
+                                    onAccept(scheduledTasks)
                                 }
-                                // Always trigger next proposal
-                                onAccept(scheduledTasks)
                             }
                         }
                     }) {
@@ -319,35 +323,6 @@ struct ProposalMessageCard: View {
                 },
                 onDismiss: {
                     showingAddTaskSheet = false
-                }
-            )
-        }
-        .sheet(isPresented: $showingModificationReasonPopup) {
-            ModificationReasonSheet(
-                reason: $modificationReason,
-                originalTime: pendingOriginalTime,
-                modifiedTime: pendingModifiedTime,
-                tasks: pendingAcceptTasks,
-                onSubmit: { reason in
-                    // Save modification reason to agent memory
-                    schedulingViewModel.saveModificationReason(
-                        reason: reason,
-                        originalTime: pendingOriginalTime,
-                        modifiedTime: pendingModifiedTime,
-                        tasks: pendingAcceptTasks
-                    )
-                    modificationReason = ""
-                    pendingAcceptTasks = []
-                    pendingOriginalTime = ""
-                    pendingModifiedTime = ""
-                    showingModificationReasonPopup = false
-                },
-                onSkip: {
-                    modificationReason = ""
-                    pendingAcceptTasks = []
-                    pendingOriginalTime = ""
-                    pendingModifiedTime = ""
-                    showingModificationReasonPopup = false
                 }
             )
         }

--- a/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
+++ b/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
@@ -9,6 +9,13 @@ import SwiftUI
 import SwiftData
 import FirebaseAuth
 
+struct ModificationContext: Identifiable {
+    let id = UUID()
+    let tasks: [String]
+    let originalTime: String
+    let modifiedTime: String
+}
+
 struct SmartSchedulingTestView: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var firebaseManager: FirebaseManager
@@ -28,6 +35,8 @@ struct SmartSchedulingTestView: View {
     @State private var showingDatePicker = false
     @State private var scheduledTasks: Set<String> = [] // Track scheduled task titles
     @State private var planningDate: Date? = nil // Fixed date for current agent session
+    @State private var pendingModificationContext: ModificationContext? = nil
+    @State private var modificationReason = ""
     
     var body: some View {
         NavigationView {
@@ -73,6 +82,36 @@ struct SmartSchedulingTestView: View {
                             planningDate = nil
                         }
                     }
+            }
+            .sheet(item: $pendingModificationContext) { context in
+                ModificationReasonSheet(
+                    reason: $modificationReason,
+                    originalTime: context.originalTime,
+                    modifiedTime: context.modifiedTime,
+                    tasks: context.tasks,
+                    onSubmit: { reason in
+                        schedulingViewModel.saveModificationReason(
+                            reason: reason,
+                            originalTime: context.originalTime,
+                            modifiedTime: context.modifiedTime,
+                            tasks: context.tasks
+                        )
+                        handleAcceptedTasks(context.tasks)
+                        modificationReason = ""
+                        pendingModificationContext = nil
+                    },
+                    onSkip: {
+                        schedulingViewModel.saveModificationReason(
+                            reason: "",
+                            originalTime: context.originalTime,
+                            modifiedTime: context.modifiedTime,
+                            tasks: context.tasks
+                        )
+                        handleAcceptedTasks(context.tasks)
+                        modificationReason = ""
+                        pendingModificationContext = nil
+                    }
+                )
             }
             .onAppear {
                 refreshData()
@@ -315,15 +354,11 @@ struct SmartSchedulingTestView: View {
                                         schedulingViewModel: schedulingViewModel,
                                         backlogViewModel: backlogViewModel,
                                         onAccept: { taskTitles in
-                                            // Mark tasks as processed (scheduled or skipped)
-                                            if !taskTitles.isEmpty {
-                                                for taskTitle in taskTitles {
-                                                    scheduledTasks.insert(taskTitle)
-                                                }
-                                            }
-                                            // Clear proposal and propose next session
-                                            schedulingViewModel.currentProposal = nil
-                                            proposeNextSession()
+                                            handleAcceptedTasks(taskTitles)
+                                        },
+                                        onRequestModificationReason: { context in
+                                            modificationReason = ""
+                                            pendingModificationContext = context
                                         }
                                     )
                                     Spacer()
@@ -455,6 +490,16 @@ struct SmartSchedulingTestView: View {
         selectedTab = 1
         
         // Propose first working session using the fixed planning date
+        proposeNextSession()
+    }
+
+    private func handleAcceptedTasks(_ taskTitles: [String]) {
+        if !taskTitles.isEmpty {
+            for taskTitle in taskTitles {
+                scheduledTasks.insert(taskTitle)
+            }
+        }
+        schedulingViewModel.currentProposal = nil
         proposeNextSession()
     }
     
@@ -1186,4 +1231,3 @@ struct StatBadge: View {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Avoid presenting the modification-reason sheet from inside `ProposalMessageCard` so the parent view can manage presentation lifecycle and delay final acceptance until feedback is stored.
- Ensure non-modified accepts continue to proceed immediately while modified accepts allow the user to provide optional feedback before advancing.

### Description
- Added `ModificationContext` and moved modification sheet state into `SmartSchedulingTestView` via `@State private var pendingModificationContext` and `@State private var modificationReason` and present it with `.sheet(item:)`.
- Reworked `ProposalMessageCard` to accept a new callback `onRequestModificationReason: (ModificationContext) -> Void` and removed its local modification-sheet state, so it now sends modification context to the parent when a modified accept occurs.
- Centralized accept flow in the parent by adding `handleAcceptedTasks(_:)` which clears the current proposal and calls `proposeNextSession()` after feedback is saved or skipped.
- Kept immediate behavior for non-modified accepts by still calling `onAccept` immediately when no modifications were detected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d698d50a08325a248bae24e50774b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the proposal-acceptance control flow by deferring final acceptance for modified proposals until after an optional feedback sheet is handled, which could affect proposal progression and state cleanup if edge cases are missed.
> 
> **Overview**
> **Modification feedback is now owned by the parent chat view instead of the proposal card.** `ProposalMessageCard` drops its internal modification-reason sheet/state and adds an `onRequestModificationReason(ModificationContext)` callback; accepting a modified proposal now emits context (tasks + original/modified time) rather than immediately advancing.
> 
> `SmartSchedulingTestView` introduces `ModificationContext`, presents `ModificationReasonSheet` via `.sheet(item:)`, persists feedback (or an empty reason on skip), then centralizes the post-accept flow in `handleAcceptedTasks(_:)` to mark tasks processed, clear the current proposal, and propose the next session. Non-modified accepts still complete immediately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3dab153c609f2f066e467a9bd345c73a1edea9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->