### PR TITLE
Capture original proposal tasks to detect removals as modifications

### DIFF
--- a/YourDay/Views/Scheduling/ProposalMessageCard.swift
+++ b/YourDay/Views/Scheduling/ProposalMessageCard.swift
@@ -23,6 +23,7 @@ struct ProposalMessageCard: View {
     @State private var pendingAcceptTasks: [String] = [] // Tasks to mark as accepted after reason submitted
     @State private var pendingOriginalTime = "" // Captured original time for popup
     @State private var pendingModifiedTime = "" // Captured modified time for popup
+    @State private var originalTasks: [String]
 
     init(proposal: Binding<ProposedSession>, schedulingViewModel: SchedulingAssistantViewModel, backlogViewModel: BacklogViewModel, onAccept: @escaping ([String]) -> Void) {
         self._proposal = proposal
@@ -35,6 +36,7 @@ struct ProposalMessageCard: View {
         let initialDuration = proposal.wrappedValue.effectiveDuration ?? 60
         _selectedStartTime = State(initialValue: initialStart)
         _adjustedDuration = State(initialValue: initialDuration)
+        _originalTasks = State(initialValue: proposal.wrappedValue.tasks)
     }
 
     // Backlog items that are not already in the proposal
@@ -45,10 +47,7 @@ struct ProposalMessageCard: View {
     }
 
     private var hasModifications: Bool {
-        // Check if tasks were added
-        if !addedTaskTitles.isEmpty {
-            return true
-        }
+        let tasksChanged = Set(originalTasks) != Set(proposal.tasks)
 
         guard let originalStart = proposal.startTime else { return false }
         let originalDuration = proposal.effectiveDuration ?? 60
@@ -57,7 +56,7 @@ struct ProposalMessageCard: View {
         let startChanged = !calendar.isDate(selectedStartTime, equalTo: originalStart, toGranularity: .minute)
         let durationChanged = adjustedDuration != originalDuration
 
-        return startChanged || durationChanged
+        return tasksChanged || startChanged || durationChanged
     }
 
     private var effectiveEndTime: Date {


### PR DESCRIPTION
### Motivation
- Ensure that removing tasks from a proposed session is detected as a modification so the UI shows the "Accept Modified" label and the modification reason sheet, while preserving existing time/duration modification detection.

### Description
- Add `@State private var originalTasks: [String]` initialized from `proposal.wrappedValue.tasks` in `init`, and update `hasModifications` to compute `tasksChanged = Set(originalTasks) != Set(proposal.tasks)` and include it in the final modification check while keeping the existing start time and duration checks.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d698fc96883259e8083a5cd984206)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `hasModifications` logic that drives accept/feedback flows, and the updated `ProposalMessageCard` initializer signature/state additions could introduce compile-time or UI-state issues if mismatched at call sites.
> 
> **Overview**
> Updates `ProposalMessageCard` to persist the proposal’s original task list (`originalTasks`) and treat any task list change (including removals) as a modification by comparing `Set(originalTasks)` vs `Set(proposal.tasks)`.
> 
> This expands the conditions that trigger the “modified” UI/accept flow to include task edits in addition to start-time and duration changes, and adds several new `@State` fields intended to support modification-reason handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6008bea58d4f7630dea164a4551c42f80e7f7fce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->