### PR TITLE
Add day-of-week memories to schedule preferences and batch-analysis of modification reasons

### DIFF
--- a/YourDay/ViewModels/Preferences/UserSchedulePreference.swift
+++ b/YourDay/ViewModels/Preferences/UserSchedulePreference.swift
@@ -134,12 +134,13 @@ struct UserSchedulePreference: Codable {
     var preferredWorkTimes: [String]? // Array of preferred time ranges
     var blockedTimes: [String]? // Array of blocked time ranges
     var learnedPatterns: [String: String]? // Key-value pairs of learned patterns
+    var dayOfWeekMemories: [String: [String]]? // Day-of-week memories extracted from modification reasons
     var scheduleConstraints: [ScheduleConstraint] = [] // General constraints learned from user feedback
     var recurringCommitments: [RecurringCommitment] = []
     var dayContexts: [String: DayContext]? // Day-specific contexts keyed by day name (monday, tuesday, etc.)
     var acceptanceStats: AcceptanceStats? // Aggregated stats for learning
 
-    init(id: String? = nil, userId: String, preferredWakeTime: String? = nil, lunchTime: String? = nil, preferredWorkTimes: [String]? = nil, blockedTimes: [String]? = nil, learnedPatterns: [String: String]? = nil, scheduleConstraints: [ScheduleConstraint] = [], recurringCommitments: [RecurringCommitment] = [], dayContexts: [String: DayContext]? = nil, acceptanceStats: AcceptanceStats? = nil) {
+    init(id: String? = nil, userId: String, preferredWakeTime: String? = nil, lunchTime: String? = nil, preferredWorkTimes: [String]? = nil, blockedTimes: [String]? = nil, learnedPatterns: [String: String]? = nil, dayOfWeekMemories: [String: [String]]? = nil, scheduleConstraints: [ScheduleConstraint] = [], recurringCommitments: [RecurringCommitment] = [], dayContexts: [String: DayContext]? = nil, acceptanceStats: AcceptanceStats? = nil) {
         self.id = id
         self.userId = userId
         self.preferredWakeTime = preferredWakeTime
@@ -147,10 +148,10 @@ struct UserSchedulePreference: Codable {
         self.preferredWorkTimes = preferredWorkTimes
         self.blockedTimes = blockedTimes
         self.learnedPatterns = learnedPatterns
+        self.dayOfWeekMemories = dayOfWeekMemories
         self.scheduleConstraints = scheduleConstraints
         self.recurringCommitments = recurringCommitments
         self.dayContexts = dayContexts
         self.acceptanceStats = acceptanceStats
     }
 }
-

--- a/YourDay/ViewModels/ViewModels/SchedulingAssistantViewModel.swift
+++ b/YourDay/ViewModels/ViewModels/SchedulingAssistantViewModel.swift
@@ -11,6 +11,14 @@ import FirebaseVertexAI
 import FirebaseAuth
 import GoogleSignIn
 
+struct ModificationReasonInput {
+    let dayOfWeek: String
+    let originalTime: String
+    let modifiedTime: String
+    let tasks: [String]
+    let reason: String
+}
+
 @MainActor
 class SchedulingAssistantViewModel: ObservableObject {
     @Published var messages: [SchedulingMessage] = []
@@ -500,6 +508,14 @@ class SchedulingAssistantViewModel: ObservableObject {
             return text
         }.joined(separator: "\n")
     }
+
+    private func formatDayOfWeekMemories(for dayOfWeek: String) -> String {
+        guard let memories = schedulePreference?.dayOfWeekMemories?[dayOfWeek.lowercased()], !memories.isEmpty else {
+            return "None"
+        }
+
+        return memories.map { "- \($0)" }.joined(separator: "\n")
+    }
     
     // MARK: - AI Integration
 
@@ -546,6 +562,7 @@ class SchedulingAssistantViewModel: ObservableObject {
             let dayOfWeek = self.getDayOfWeekString(from: date)
             let dayContext = self.dayContexts[dayOfWeek]
             let dayContextText = self.formatDayContext(dayContext, dayOfWeek: dayOfWeek)
+            let dayOfWeekMemoriesText = self.formatDayOfWeekMemories(for: dayOfWeek)
 
             // Get schedule notes for this date
             let scheduleNotesText = self.formatScheduleNotes()
@@ -601,6 +618,9 @@ class SchedulingAssistantViewModel: ObservableObject {
 
             Day-Specific Context for \(dayOfWeek.capitalized):
             \(dayContextText)
+
+            Learned Day-of-Week Memories for \(dayOfWeek.capitalized):
+            \(dayOfWeekMemoriesText)
 
             Schedule Notes for This Date:
             \(scheduleNotesText)
@@ -1209,6 +1229,77 @@ class SchedulingAssistantViewModel: ObservableObject {
             )
             messages.append(message)
             firebaseManager.saveSchedulingMessage(message) { _ in }
+        }
+    }
+
+    func analyzeModificationReasonsBatch(_ modifications: [ModificationReasonInput]) {
+        let trimmedModifications = modifications.compactMap { modification -> ModificationReasonInput? in
+            let trimmedReason = modification.reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedReason.isEmpty else { return nil }
+            return ModificationReasonInput(
+                dayOfWeek: modification.dayOfWeek,
+                originalTime: modification.originalTime,
+                modifiedTime: modification.modifiedTime,
+                tasks: modification.tasks,
+                reason: trimmedReason
+            )
+        }
+
+        guard !trimmedModifications.isEmpty else { return }
+
+        let grouped = Dictionary(grouping: trimmedModifications, by: { $0.dayOfWeek.lowercased() })
+        let groupedSummary = grouped.keys.sorted().map { day in
+            let items = grouped[day, default: []]
+            let lines = items.map { item in
+                "- Tasks: \(item.tasks.joined(separator: ", ")); Original: \(item.originalTime); Modified: \(item.modifiedTime); Reason: \(item.reason)"
+            }.joined(separator: "\n")
+            return "\(day.capitalized):\n\(lines)"
+        }.joined(separator: "\n\n")
+
+        let analysisPrompt = """
+        The user provided reasons for modifying scheduled sessions. Extract day-of-week specific memories that can guide future scheduling.
+
+        Reasons grouped by day of week:
+        \(groupedSummary)
+
+        Return JSON in this format:
+        {
+            "dayOfWeekMemories": {
+                "monday": ["Memory 1", "Memory 2"],
+                "tuesday": ["Memory 1"]
+            }
+        }
+
+        Only include days that have meaningful, actionable memories. Keep memories short and specific.
+        """
+
+        Task {
+            do {
+                let vertex = VertexAI.vertexAI()
+                let model = vertex.generativeModel(modelName: "gemini-2.5-flash")
+
+                let analysisMessage = ModelContent(role: "user", parts: [TextPart(analysisPrompt)])
+                let response = try await model.generateContent([analysisMessage])
+
+                guard let text = response.text,
+                      let data = text.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let memories = json["dayOfWeekMemories"] as? [String: [String]] else {
+                    return
+                }
+
+                var updatedMemories = schedulePreference?.dayOfWeekMemories ?? [:]
+                for (day, dayMemories) in memories {
+                    let normalizedDay = day.lowercased()
+                    let existing = updatedMemories[normalizedDay] ?? []
+                    let merged = existing + dayMemories.filter { !existing.contains($0) }
+                    updatedMemories[normalizedDay] = merged
+                }
+
+                updateSchedulePreference(["dayOfWeekMemories": updatedMemories])
+            } catch {
+                print("Error analyzing modification reasons batch: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/YourDay/Views/Scheduling/ProposalMessageCard.swift
+++ b/YourDay/Views/Scheduling/ProposalMessageCard.swift
@@ -255,7 +255,9 @@ struct ProposalMessageCard: View {
                                         ModificationContext(
                                             tasks: scheduledTasks,
                                             originalTime: originalTime,
-                                            modifiedTime: modifiedTimeStr
+                                            modifiedTime: modifiedTimeStr,
+                                            dayOfWeek: dayOfWeekString(from: schedulingViewModel.selectedDate),
+                                            reason: nil
                                         )
                                     )
                                 } else {
@@ -350,6 +352,12 @@ struct ProposalMessageCard: View {
                 }
             )
         }
+    }
+
+    private func dayOfWeekString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE"
+        return formatter.string(from: date).lowercased()
     }
 
     // MARK: - Task Management

--- a/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
+++ b/YourDay/Views/Scheduling/SmartSchedulingTestView.swift
@@ -14,6 +14,8 @@ struct ModificationContext: Identifiable {
     let tasks: [String]
     let originalTime: String
     let modifiedTime: String
+    let dayOfWeek: String
+    var reason: String?
 }
 
 struct SmartSchedulingTestView: View {
@@ -98,12 +100,14 @@ struct SmartSchedulingTestView: View {
                     modifications: $pendingModifications,
                     currentIndex: $currentModificationIndex,
                     reason: $modificationReason,
-                    schedulingViewModel: schedulingViewModel,
                     onComplete: {
                         showingModificationReview = false
-                        pendingModifications.removeAll()
-                        currentModificationIndex = 0
                         modificationReason = ""
+                        if !isAgentRunning {
+                            processModificationReasonsBatch()
+                            pendingModifications.removeAll()
+                            currentModificationIndex = 0
+                        }
                     }
                 )
             }
@@ -428,6 +432,9 @@ struct SmartSchedulingTestView: View {
                     onRequestModificationReason: { context in
                         // Store modification for later review and continue immediately
                         pendingModifications.append(context)
+                        currentModificationIndex = nextPendingModificationIndex() ?? (pendingModifications.count - 1)
+                        modificationReason = pendingModifications[currentModificationIndex].reason ?? ""
+                        showingModificationReview = true
                         handleAcceptedTasks(context.tasks)
                     },
                     isDisabled: schedulingViewModel.showingDeclineReasonInput
@@ -616,9 +623,11 @@ struct SmartSchedulingTestView: View {
 
             // Show modification review if there are pending modifications
             if !pendingModifications.isEmpty {
-                currentModificationIndex = 0
-                modificationReason = ""
-                showingModificationReview = true
+                if !showingModificationReview {
+                    processModificationReasonsBatch()
+                    pendingModifications.removeAll()
+                    currentModificationIndex = 0
+                }
             }
             return
         }
@@ -656,6 +665,23 @@ struct SmartSchedulingTestView: View {
         backlogViewModel.fetchBacklogItems(todoItems: todoItems)
         fetchCalendarForDate()
         schedulingViewModel.fetchSchedulePreference()
+    }
+
+    private func nextPendingModificationIndex() -> Int? {
+        pendingModifications.firstIndex { ($0.reason ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    private func processModificationReasonsBatch() {
+        let inputs = pendingModifications.map { modification in
+            ModificationReasonInput(
+                dayOfWeek: modification.dayOfWeek,
+                originalTime: modification.originalTime,
+                modifiedTime: modification.modifiedTime,
+                tasks: modification.tasks,
+                reason: modification.reason ?? ""
+            )
+        }
+        schedulingViewModel.analyzeModificationReasonsBatch(inputs)
     }
 }
 
@@ -1378,7 +1404,6 @@ struct ModificationReviewSheet: View {
     @Binding var modifications: [ModificationContext]
     @Binding var currentIndex: Int
     @Binding var reason: String
-    @ObservedObject var schedulingViewModel: SchedulingAssistantViewModel
     let onComplete: () -> Void
 
     @FocusState private var isTextFieldFocused: Bool
@@ -1562,25 +1587,25 @@ struct ModificationReviewSheet: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
+        .onChange(of: currentIndex) { _, newIndex in
+            if newIndex < modifications.count {
+                reason = modifications[newIndex].reason ?? ""
+            }
+        }
     }
 
     private func saveCurrentAndAdvance() {
         isTextFieldFocused = false
 
-        if let mod = currentModification {
-            schedulingViewModel.saveModificationReason(
-                reason: reason,
-                originalTime: mod.originalTime,
-                modifiedTime: mod.modifiedTime,
-                tasks: mod.tasks
-            )
+        if currentModification != nil {
+            modifications[currentIndex].reason = reason
         }
 
         reason = ""
 
-        if currentIndex < modifications.count - 1 {
+        if let nextIndex = modifications.firstIndex(where: { ($0.reason ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
             withAnimation(.easeInOut(duration: 0.2)) {
-                currentIndex += 1
+                currentIndex = nextIndex
             }
         } else {
             onComplete()
@@ -1592,13 +1617,7 @@ struct ModificationReviewSheet: View {
 
         // Save all remaining modifications with empty reason
         for i in currentIndex..<modifications.count {
-            let mod = modifications[i]
-            schedulingViewModel.saveModificationReason(
-                reason: i == currentIndex ? reason : "",
-                originalTime: mod.originalTime,
-                modifiedTime: mod.modifiedTime,
-                tasks: mod.tasks
-            )
+            modifications[i].reason = i == currentIndex ? reason : ""
         }
 
         onComplete()


### PR DESCRIPTION
### Motivation
- Persist short, actionable "memories" derived from users' modification reasons into the user's schedule preferences so the assistant can use them as day-specific context when proposing sessions.
- Collect modification reasons in the UI and batch-analyze them to produce compact day-of-week memories that inform future scheduling decisions.

### Description
- Added a new `dayOfWeekMemories: [String: [String]]?` field to `UserSchedulePreference` and updated its initializer to persist day-specific memories.
- Injected day-of-week memories into the scheduling prompt by adding `formatDayOfWeekMemories` and including the result in `SchedulingAssistantViewModel.proposeWorkingSession` so the AI sees learned day-specific hints.
- Implemented batch processing: introduced `ModificationReasonInput` and `analyzeModificationReasonsBatch(_:)` in `SchedulingAssistantViewModel` which groups edits by day, calls the Vertex AI model to extract concise memories, merges them into existing `dayOfWeekMemories`, and updates preferences via `updateSchedulePreference`.
- Updated the UI to collect modification contexts and reasons: `ProposalMessageCard` now includes the day-of-week when requesting modification reasons; `SmartSchedulingTestView` queues pending modifications, shows the modification review sheet, and triggers the batch analysis at appropriate times; `ModificationReviewSheet` was adjusted to capture reasons into the local batch rather than directly saving each reason.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f8d16f32c8325930a1233388799e4)